### PR TITLE
raw pia data physics explanation

### DIFF
--- a/PixelTKFECSupervisor/src/common/PixelTKFECSupervisor.cc
+++ b/PixelTKFECSupervisor/src/common/PixelTKFECSupervisor.cc
@@ -3377,8 +3377,7 @@ void PixelTKFECSupervisor::FPixDCDCSummary(xgi::Input* in, xgi::Output* out ) th
         for (int i = 0; i < 3; ++i)
           *out << "<td>" << ddr[slot][ring][ccu][i] << "</td>";
         *out << "</tr>\n";
-        *out << "<tr><td>data</td>\n";
-        *out << "This is a new line";
+        *out << "<tr><td>data</td>";
         for (int i = 0; i < 3; ++i)
           *out << "<td>" << data[slot][ring][ccu][i] << "</td>";
         *out << "</tr>\n";
@@ -3394,11 +3393,14 @@ void PixelTKFECSupervisor::FPixDCDCSummary(xgi::Input* in, xgi::Output* out ) th
 	    else
 	      M[8 - i - 1] = false;
 	  }
+          *out <<"<tr><td>";
 	  for (int i = 0; i < 8; i++)
 	    *out << M[i];
-	  *out << endl;
+	  *out << "</td>";
+          *out << "</tr>\n";
           for (int bit = 0; bit < 8; bit++)
-	    std::cout << "Channel=" << channelnumber << ";bit=" << bit << ";value=" << (M[bit]) << ":" << (MessageMatrix[channelnumber][bit].c_str()) << " = "<< (M[bit] ? "GOOD" : "Bad") << "." << std::endl;
+	    *out << "<tr><td>Channel=" << channelnumber << ";bit=" << bit << ";value=" << (M[8-bit-1]) << ":" << (MessageMatrix[channelnumber][bit].c_str()) << " = "<< (M[8-1-bit] ? "GOOD" : "Bad") << "." << "</td></tr>\n";
+          *out <<"</tr>\n";
 
 	}
         *out << "</table>\n";

--- a/PixelTKFECSupervisor/src/common/PixelTKFECSupervisor.cc
+++ b/PixelTKFECSupervisor/src/common/PixelTKFECSupervisor.cc
@@ -3342,15 +3342,16 @@ void PixelTKFECSupervisor::FPixDCDCSummary(xgi::Input* in, xgi::Output* out ) th
   
   enum PIARegisterType{
     GoodAndBad=1,
-    OnAndOff=2
+    OnAndOff=2,
+    EnableAndDisable=3
   };
   PIARegisterType regType[3][8];
-  regType[0][0]=OnAndOff;
-  regType[0][1]=OnAndOff;
-  regType[0][2]=OnAndOff;
-  regType[0][3]=OnAndOff;
-  regType[0][4]=OnAndOff;
-  regType[0][5]=OnAndOff;
+  regType[0][0]=EnableAndDisable;
+  regType[0][1]=EnableAndDisable;
+  regType[0][2]=EnableAndDisable;
+  regType[0][3]=EnableAndDisable;
+  regType[0][4]=EnableAndDisable;
+  regType[0][5]=EnableAndDisable;
   regType[0][6]=GoodAndBad;
   regType[0][7]=GoodAndBad;
   regType[1][0]=OnAndOff;
@@ -3371,26 +3372,26 @@ void PixelTKFECSupervisor::FPixDCDCSummary(xgi::Input* in, xgi::Output* out ) th
   regType[2][7]=GoodAndBad;
 
   string MessageMatrix[3][8];
-  MessageMatrix[0][0] = "J11 dcdc converter on P1";
-  MessageMatrix[0][1] = "J12 dcdc converter on P1";
-  MessageMatrix[0][2] = "J11 dcdc converter on P2";
-  MessageMatrix[0][3] = "J12 dcdc converter on P2";
-  MessageMatrix[0][4] = "J11 dcdc converter on P3";
-  MessageMatrix[0][5] = "J12 dcdc converter on P3";
+  MessageMatrix[0][0] = "J11 dcdc converter pair setting on P1";
+  MessageMatrix[0][1] = "J12 dcdc converter pair setting on P1";
+  MessageMatrix[0][2] = "J11 dcdc converter pair setting on P2";
+  MessageMatrix[0][3] = "J12 dcdc converter pair setting on P2";
+  MessageMatrix[0][4] = "J11 dcdc converter pair setting on P3";
+  MessageMatrix[0][5] = "J12 dcdc converter pair setting on P3";
   MessageMatrix[0][6] = "always 1";
   MessageMatrix[0][7] = "always 1";
-  MessageMatrix[1][0] = "bit 0 dcdc power for P1";
-  MessageMatrix[1][1] = "bit 1 dcdc power for P1";
-  MessageMatrix[1][2] = "bit 2 dcdc power for P1";
-  MessageMatrix[1][3] = "bit 3 dcdc power for P1";
-  MessageMatrix[1][4] = "bit 4 dcdc power for P2";
-  MessageMatrix[1][5] = "bit 5 dcdc power for P2";
-  MessageMatrix[1][6] = "bit 6 dcdc power for P2";
-  MessageMatrix[1][7] = "bit 7 dcdc power for P2";
-  MessageMatrix[2][0] = "bit 0 dcdc power for P3";
-  MessageMatrix[2][1] = "bit 1 dcdc power for P3";
-  MessageMatrix[2][2] = "bit 2 dcdc power for P3";
-  MessageMatrix[2][3] = "bit 3 dcdc power for P3";
+  MessageMatrix[1][0] = "bit 0 dcdc power_Good from P1";
+  MessageMatrix[1][1] = "bit 1 dcdc power_Good from P1";
+  MessageMatrix[1][2] = "bit 2 dcdc power_Good from P1";
+  MessageMatrix[1][3] = "bit 3 dcdc power_Good from P1";
+  MessageMatrix[1][4] = "bit 4 dcdc power_Good from P2";
+  MessageMatrix[1][5] = "bit 5 dcdc power_Good from P2";
+  MessageMatrix[1][6] = "bit 6 dcdc power_Good from P2";
+  MessageMatrix[1][7] = "bit 7 dcdc power_Good from P2";
+  MessageMatrix[2][0] = "bit 0 dcdc power_Good from P3";
+  MessageMatrix[2][1] = "bit 1 dcdc power_Good from P3";
+  MessageMatrix[2][2] = "bit 2 dcdc power_Good from P3";
+  MessageMatrix[2][3] = "bit 3 dcdc power_Good from P3";
   MessageMatrix[2][4] = "qpll lock for P1";
   MessageMatrix[2][5] = "qpll lock for P2";
   MessageMatrix[2][6] = "qpll lock for P3";
@@ -3438,8 +3439,10 @@ void PixelTKFECSupervisor::FPixDCDCSummary(xgi::Input* in, xgi::Output* out ) th
             string StatusPIA="";
             if(regType[channelnumber][bit]==PIARegisterType::OnAndOff)
               StatusPIA=M[bit]? "On":"Off";
-            else
+            else if(regType[channelnumber][bit]==PIARegisterType::GoodAndBad)
               StatusPIA=M[bit]? "Good":"bad";
+            else
+              StatusPIA=M[bit]? "Disable":"Enable";
             *out << "Channel=" << channelnumber << ";bit=" << bit << ";value=" << (M[bit]) << ":" << (MessageMatrix[channelnumber][bit].c_str()) << " = "<< StatusPIA << "." << "<br/>";
           }
           *out <<"</p>";

--- a/PixelTKFECSupervisor/src/common/PixelTKFECSupervisor.cc
+++ b/PixelTKFECSupervisor/src/common/PixelTKFECSupervisor.cc
@@ -3340,6 +3340,31 @@ void PixelTKFECSupervisor::FPixDCDCSummary(xgi::Input* in, xgi::Output* out ) th
     enable_pgood[pc_name] = std::make_pair(enable, pgood);
   }
 
+  string MessageMatrix[3][8];
+  MessageMatrix[0][0] = "J11 dcdc converter on P1";
+  MessageMatrix[0][1] = "J12 dcdc converter on P1";
+  MessageMatrix[0][2] = "J11 dcdc converter on P2";
+  MessageMatrix[0][3] = "J12 dcdc converter on P2";
+  MessageMatrix[0][4] = "J11 dcdc converter on P3";
+  MessageMatrix[0][5] = "J12 dcdc converter on P3";
+  MessageMatrix[0][6] = "always 1";
+  MessageMatrix[0][7] = "always 1";
+  MessageMatrix[1][0] = "bit 0 dcdc power for P1";
+  MessageMatrix[1][1] = "bit 1 dcdc power for P1";
+  MessageMatrix[1][2] = "bit 2 dcdc power for P1";
+  MessageMatrix[1][3] = "bit 3 dcdc power for P1";
+  MessageMatrix[1][4] = "bit 4 dcdc power for P2";
+  MessageMatrix[1][5] = "bit 5 dcdc power for P2";
+  MessageMatrix[1][6] = "bit 6 dcdc power for P2";
+  MessageMatrix[1][7] = "bit 7 dcdc power for P2";
+  MessageMatrix[2][0] = "bit 0 dcdc power for P3";
+  MessageMatrix[2][1] = "bit 1 dcdc power for P3";
+  MessageMatrix[2][2] = "bit 2 dcdc power for P3";
+  MessageMatrix[2][3] = "bit 3 dcdc power for P3";
+  MessageMatrix[2][4] = "qpll lock for P1";
+  MessageMatrix[2][5] = "qpll lock for P2";
+  MessageMatrix[2][6] = "qpll lock for P3";
+  MessageMatrix[2][7] = "always 1 in my experience but I'm not sure what it's hooked to";
   *out << "raw pia data:<br>\n";
   *out << std::hex;
   for (int slot = 0; slot < 1; ++slot) {
@@ -3352,10 +3377,30 @@ void PixelTKFECSupervisor::FPixDCDCSummary(xgi::Input* in, xgi::Output* out ) th
         for (int i = 0; i < 3; ++i)
           *out << "<td>" << ddr[slot][ring][ccu][i] << "</td>";
         *out << "</tr>\n";
-        *out << "<tr><td>data</td>";
+        *out << "<tr><td>data</td>\n";
+        *out << "This is a new line";
         for (int i = 0; i < 3; ++i)
           *out << "<td>" << data[slot][ring][ccu][i] << "</td>";
         *out << "</tr>\n";
+        for (int channelnumber = 0; channelnumber < 3; channelnumber++)
+	{
+	  bool *M = new bool[8];
+	  for (int i = 0; i < 8; i++)
+	  {
+	    if (data[slot][ring][ccu][channelnumber] & (1 << i))
+	    {
+	      M[8 - i - 1] = true;
+	    }
+	    else
+	      M[8 - i - 1] = false;
+	  }
+	  for (int i = 0; i < 8; i++)
+	    *out << M[i];
+	  *out << endl;
+          for (int bit = 0; bit < 8; bit++)
+	    std::cout << "Channel=" << channelnumber << ";bit=" << bit << ";value=" << (M[bit]) << ":" << (MessageMatrix[channelnumber][bit].c_str()) << " = "<< (M[bit] ? "GOOD" : "Bad") << "." << std::endl;
+
+	}
         *out << "</table>\n";
       }
     }

--- a/PixelTKFECSupervisor/src/common/PixelTKFECSupervisor.cc
+++ b/PixelTKFECSupervisor/src/common/PixelTKFECSupervisor.cc
@@ -3339,6 +3339,36 @@ void PixelTKFECSupervisor::FPixDCDCSummary(xgi::Input* in, xgi::Output* out ) th
     
     enable_pgood[pc_name] = std::make_pair(enable, pgood);
   }
+  
+  enum PIARegisterType{
+    GoodAndBad=1,
+    OnAndOff=2
+  };
+  PIARegisterType regType[3][8];
+  regType[0][0]=OnAndOff;
+  regType[0][1]=OnAndOff;
+  regType[0][2]=OnAndOff;
+  regType[0][3]=OnAndOff;
+  regType[0][4]=OnAndOff;
+  regType[0][5]=OnAndOff;
+  regType[0][6]=GoodAndBad;
+  regType[0][7]=GoodAndBad;
+  regType[1][0]=OnAndOff;
+  regType[1][1]=OnAndOff;
+  regType[1][2]=OnAndOff;
+  regType[1][3]=OnAndOff;
+  regType[1][4]=OnAndOff;
+  regType[1][5]=OnAndOff;
+  regType[1][6]=OnAndOff;
+  regType[1][7]=OnAndOff;
+  regType[2][0]=OnAndOff;
+  regType[2][1]=OnAndOff;
+  regType[2][2]=OnAndOff;
+  regType[2][3]=OnAndOff;
+  regType[2][4]=GoodAndBad;
+  regType[2][5]=GoodAndBad;
+  regType[2][6]=GoodAndBad;
+  regType[2][7]=GoodAndBad;
 
   string MessageMatrix[3][8];
   MessageMatrix[0][0] = "J11 dcdc converter on P1";
@@ -3381,6 +3411,7 @@ void PixelTKFECSupervisor::FPixDCDCSummary(xgi::Input* in, xgi::Output* out ) th
         for (int i = 0; i < 3; ++i)
           *out << "<td>" << data[slot][ring][ccu][i] << "</td>";
         *out << "</tr>\n";
+        *out << "</table>\n";
         for (int channelnumber = 0; channelnumber < 3; channelnumber++)
 	{
 	  bool *M = new bool[8];
@@ -3388,22 +3419,31 @@ void PixelTKFECSupervisor::FPixDCDCSummary(xgi::Input* in, xgi::Output* out ) th
 	  {
 	    if (data[slot][ring][ccu][channelnumber] & (1 << i))
 	    {
-	      M[8 - i - 1] = true;
+	      M[i] = true;
 	    }
 	    else
-	      M[8 - i - 1] = false;
+	      M[i] = false;
 	  }
-          *out <<"<tr><td>";
-	  for (int i = 0; i < 8; i++)
-	    *out << M[i];
-	  *out << "</td>";
-          *out << "</tr>\n";
-          for (int bit = 0; bit < 8; bit++)
-	    *out << "<tr><td>Channel=" << channelnumber << ";bit=" << bit << ";value=" << (M[8-bit-1]) << ":" << (MessageMatrix[channelnumber][bit].c_str()) << " = "<< (M[8-1-bit] ? "GOOD" : "Bad") << "." << "</td></tr>\n";
-          *out <<"</tr>\n";
 
-	}
-        *out << "</table>\n";
+          *out <<"<p>";
+	  for (int i = 0; i < 8; i++)
+	    *out << M[8-1-i];
+	  *out << "<br/>";
+          *out << "</p>";
+	
+         // *out << "</table>\n";
+          *out <<"<p>";
+          for (int bit = 0; bit < 8; bit++)
+          {
+            string StatusPIA="";
+            if(regType[channelnumber][bit]==PIARegisterType::OnAndOff)
+              StatusPIA=M[bit]? "On":"Off";
+            else
+              StatusPIA=M[bit]? "Good":"bad";
+            *out << "Channel=" << channelnumber << ";bit=" << bit << ";value=" << (M[bit]) << ":" << (MessageMatrix[channelnumber][bit].c_str()) << " = "<< StatusPIA << "." << "<br/>";
+          }
+          *out <<"</p>";
+        }
       }
     }
   }


### PR DESCRIPTION
I changed one file PixelTKFECSupervisor/src/common/PixelTKFECSupervisor.cc that has raw PIA data readout, and now readout table has both original hex, and physics information associated with each binary bit. For exmple qpll lock status.