### PR TITLE
roctrimload function fixed with wordvec.clear()

### DIFF
--- a/PixelFECInterface/src/common/PixelPh1FECInterface.cc
+++ b/PixelFECInterface/src/common/PixelPh1FECInterface.cc
@@ -2243,6 +2243,7 @@ int PixelPh1FECInterface::roctrimload(int mfec, int fecchannel,
         
         writeCSregister(mfec, fecchannel, 0x17);
         
+        wordvec.clear();
     }
     
     if (fecdebug == 2) mfecbusy(mfec, fecchannel, &ch1stat, &ch2stat);


### PR DESCRIPTION
roctrimload function fixed with wordvec.clear() in the utca branch 